### PR TITLE
Fix missing Android application plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    id("com.android.application")
-    id("org.jetbrains.kotlin.android")
-    id("kotlin-kapt")
+    id("com.android.application") version "8.2.2"
+    id("org.jetbrains.kotlin.android") version "1.9.22"
+    id("kotlin-kapt") version "1.9.22"
 }
 
 android {
@@ -50,7 +50,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.10"
+        kotlinCompilerExtensionVersion = "1.5.8"
     }
 
     packaging {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,25 @@
+# Project-wide Gradle settings.
+
+# Specifies the JVM arguments used for the daemon process.
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+
+# When configured, Gradle will run in incubating parallel mode.
+org.gradle.parallel=true
+
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+android.useAndroidX=true
+
+# Kotlin code style for this project: "official" or "obsolete":
+kotlin.code.style=official
+
+# Enables namespacing of each library's R class so that its R class includes only the
+# resources declared in the library itself and none from the library's dependencies,
+# thereby reducing the size of the R class for that library
+android.nonTransitiveRClass=true
+
+# Enable Gradle build cache
+org.gradle.caching=true
+
+# Enable configuration cache
+org.gradle.configuration-cache=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,4 +14,3 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "AIBrother"
-include(":app")


### PR DESCRIPTION
Add explicit plugin versions and configure Gradle for a single-module Android project to resolve 'Plugin not found' errors.

The build failed because Gradle could not locate the `com.android.application` plugin due to missing version specifications. This PR addresses this by adding explicit versions to all plugins in `build.gradle.kts`, removing the incorrect `:app` module include from `settings.gradle.kts` (as all files are in the root), and adding a `gradle.properties` file with essential Android build settings. The Compose compiler extension version is also updated for compatibility.